### PR TITLE
Add OpenAI API route and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --test"
   },
   "dependencies": {
     "framer-motion": "^12.19.1",

--- a/src/app/api/question/route.js
+++ b/src/app/api/question/route.js
@@ -1,0 +1,52 @@
+export async function GET(request) {
+  const { searchParams } = new URL(request.url);
+  const category = searchParams.get("category") || "";
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return new Response(
+      JSON.stringify({ error: "Missing OpenAI key" }),
+      {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      }
+    );
+  }
+
+  const prompt = `Stelle eine tiefgr\u00fcndige Frage aus der Kategorie "${category}" auf Deutsch.`;
+
+  const openaiRes = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: "gpt-3.5-turbo",
+      messages: [
+        { role: "system", content: "Du generierst kurze, tiefgr\u00fcndige Fragen." },
+        { role: "user", content: prompt },
+      ],
+      temperature: 0.7,
+      max_tokens: 50,
+    }),
+  });
+
+  if (!openaiRes.ok) {
+    const errorText = await openaiRes.text();
+    console.error("OpenAI error:", errorText);
+    return new Response(
+      JSON.stringify({ error: "OpenAI request failed" }),
+      {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      }
+    );
+  }
+
+  const data = await openaiRes.json();
+  const question = data.choices?.[0]?.message?.content?.trim();
+  return new Response(
+    JSON.stringify({ question }),
+    { status: 200, headers: { "content-type": "application/json" } }
+  );
+}

--- a/src/components/DeepTalkApp.tsx
+++ b/src/components/DeepTalkApp.tsx
@@ -55,10 +55,22 @@ const categoryIcons = {
   "Liebe & Sexualität": <Brain className="w-5 h-5 inline-block mr-2 text-purple-600" />,
 };
 
-const drawAllQuestions = (filter: string[] | null = null) => {
+const drawAllQuestions = async (filter: string[] | null = null) => {
   const randomQuestions: Record<string, string> = {};
   for (const category in categories) {
     if (!filter || filter.includes(category)) {
+      try {
+        const res = await fetch(
+          `/api/question?category=${encodeURIComponent(category)}`
+        );
+        if (res.ok) {
+          const data = await res.json();
+          randomQuestions[category] = data.question;
+          continue;
+        }
+      } catch (e) {
+        // fall back to local list
+      }
       const list = categories[category];
       const random = list[Math.floor(Math.random() * list.length)];
       randomQuestions[category] = random;
@@ -80,8 +92,8 @@ export default function DeepTalkApp() {
 
   const handleDrawAll = () => {
     setIsFlipped(true);
-    setTimeout(() => {
-      setCardContent(drawAllQuestions(enabledCategories));
+    setTimeout(async () => {
+      setCardContent(await drawAllQuestions(enabledCategories));
       setIsFlipped(false);
     }, 400);
   };

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,38 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { GET } from '../src/app/api/question/route.js';
+
+const originalFetch = global.fetch;
+const originalKey = process.env.OPENAI_API_KEY;
+
+test.beforeEach(() => {
+  process.env.OPENAI_API_KEY = 'test';
+});
+
+test('GET returns question from OpenAI response', async () => {
+  global.fetch = async () => ({
+    ok: true,
+    json: async () => ({
+      choices: [{ message: { content: 'Frage' } }],
+    }),
+  });
+
+  const req = new Request('http://localhost/api/question?category=Test');
+  const res = await GET(req);
+  const data = await res.json();
+  assert.equal(data.question, 'Frage');
+});
+
+test('GET handles OpenAI failure', async () => {
+  global.fetch = async () => ({ ok: false, text: async () => 'error' });
+  const req = new Request('http://localhost/api/question?category=Test');
+  const res = await GET(req);
+  assert.equal(res.status, 500);
+});
+
+// restore fetch after tests
+test.after(() => {
+  global.fetch = originalFetch;
+  process.env.OPENAI_API_KEY = originalKey;
+});
+


### PR DESCRIPTION
## Summary
- implement `/api/question` route for generating questions via OpenAI
- fetch questions from the new API in the DeepTalk component
- add tests for the API route
- expose `npm test` script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685be4e43ab4832386093af7624d5e4d